### PR TITLE
obs-webrtc: Set HTTP headers in send_offer

### DIFF
--- a/plugins/obs-webrtc/webrtc-utils.h
+++ b/plugins/obs-webrtc/webrtc-utils.h
@@ -182,6 +182,7 @@ send_offer(std::string bearer_token, std::string endpoint_url,
 	curl_easy_setopt(c, CURLOPT_WRITEDATA, (void *)&read_buffer);
 	curl_easy_setopt(c, CURLOPT_HEADERFUNCTION, curl_header_function);
 	curl_easy_setopt(c, CURLOPT_HEADERDATA, (void *)&http_headers);
+	curl_easy_setopt(c, CURLOPT_HTTPHEADER, headers);
 	curl_easy_setopt(c, CURLOPT_URL, endpoint_url.c_str());
 	curl_easy_setopt(c, CURLOPT_POST, 1L);
 	curl_easy_setopt(c, CURLOPT_COPYPOSTFIELDS, offer_sdp.c_str());


### PR DESCRIPTION
Adds a line in `send_offer()` in `webrtc-utils.h` to properly set the HTTP headers.

This fixes an issue on the `whep` branch where WHIP/WHEP endpoints that check if the Content-Type header is set to application/sdp would reject the request from OBS.